### PR TITLE
Remove Type Ahead from related recipes

### DIFF
--- a/operators/filtering/throttletime.md
+++ b/operators/filtering/throttletime.md
@@ -58,7 +58,6 @@ const subscribe = example.subscribe(val => console.log(val));
 ### Related Recipes
 
 - [Horizontal Scroll Indicator](../../recipes/horizontal-scroll-indicator.md)
-- [Type Ahead](../../recipes/type-ahead.md)
 
 ### Additional Resources
 


### PR DESCRIPTION
Remove `Type Ahead` from related recipes when it's not used there